### PR TITLE
fix: update ObjectUtils serialization to use bracket notation for arr…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -738,15 +738,15 @@ export class ObjectUtils {
 			if (value === undefined) continue;
 
 			if (Array.isArray(value)) {
-				// Handle arrays: repeat the same key for each item
+				// Handle arrays: use bracket notation to preserve array type
 				for (const item of value) {
 					// Skip undefined items in arrays
 					if (item === undefined) continue;
 
 					if (typeof item === 'object' && item !== null) {
-						params.push(encodeURIComponent(key) + '=' + encodeURIComponent(JSON.stringify(item)));
+						params.push(encodeURIComponent(key) + '[]=' + encodeURIComponent(JSON.stringify(item)));
 					} else {
-						params.push(encodeURIComponent(key) + '=' + encodeURIComponent(item));
+						params.push(encodeURIComponent(key) + '[]=' + encodeURIComponent(item));
 					}
 				}
 			} else if (typeof value === 'object' && value !== null) {

--- a/tests/ObjectUtils.spec.ts
+++ b/tests/ObjectUtils.spec.ts
@@ -163,11 +163,11 @@ describe('ObjectUtils', () => {
 			expect(result).to.equal('name=test&value=123');
 		});
 
-		it('should handle array values with primitives', () => {
-			const obj = { ids: [1, 2, 3] };
-			const result = ObjectUtils.serialize(obj);
-			expect(result).to.equal('ids=1&ids=2&ids=3');
-		});
+	it('should handle array values with primitives', () => {
+		const obj = { ids: [1, 2, 3] };
+		const result = ObjectUtils.serialize(obj);
+		expect(result).to.equal('ids[]=1&ids[]=2&ids[]=3');
+	});
 
 		it('should handle array of objects with undefined values', () => {
 			const obj = {
@@ -194,12 +194,12 @@ describe('ObjectUtils', () => {
 				countryCode: 'US',
 				customItems: undefined
 			};
-		const result = ObjectUtils.serialize(obj);
+			const result = ObjectUtils.serialize(obj);
 
 		// Build expected result - JSON.stringify omits undefined properties from objects
 		// So variantId, subscriptionIntervalCount, and subscriptionPlanId will be omitted
-		const expectedItem0 = 'items=' + encodeURIComponent(JSON.stringify(obj.items[0]));
-		const expectedItem1 = 'items=' + encodeURIComponent(JSON.stringify(obj.items[1]));
+		const expectedItem0 = 'items[]=' + encodeURIComponent(JSON.stringify(obj.items[0]));
+		const expectedItem1 = 'items[]=' + encodeURIComponent(JSON.stringify(obj.items[1]));
 		const expectedCustomerUserId = 'customerUserId=31';
 		const expectedPostalCode = 'postalCode=84660';
 		const expectedCountryCode = 'countryCode=US';
@@ -207,6 +207,40 @@ describe('ObjectUtils', () => {
 
 			expect(result).to.include(expectedItem0);
 			expect(result).to.include(expectedItem1);
+			expect(result).to.include(expectedCustomerUserId);
+			expect(result).to.include(expectedPostalCode);
+			expect(result).to.include(expectedCountryCode);
+			expect(result).to.not.include('customItems');
+		});
+
+		it('should handle array with one object with undefined values', () => {
+			const obj = {
+				items: [
+					{
+						productId: 6,
+						quantity: 1,
+						variantId: undefined,
+						subscriptionIntervalUnit: 'MONTH',
+						subscriptionIntervalCount: undefined,
+						subscriptionPlanId: undefined
+					}
+				],
+				customerUserId: 31,
+				postalCode: '84660',
+				countryCode: 'US',
+				customItems: undefined
+			};
+			const result = ObjectUtils.serialize(obj);
+
+		// Build expected result - JSON.stringify omits undefined properties from objects
+		// So variantId, subscriptionIntervalCount, and subscriptionPlanId will be omitted
+		const expectedItem0 = 'items[]=' + encodeURIComponent(JSON.stringify(obj.items[0]));
+		const expectedCustomerUserId = 'customerUserId=31';
+		const expectedPostalCode = 'postalCode=84660';
+		const expectedCountryCode = 'countryCode=US';
+		// customItems is undefined at root level, so it should be skipped by serialize
+
+			expect(result).to.include(expectedItem0);
 			expect(result).to.include(expectedCustomerUserId);
 			expect(result).to.include(expectedPostalCode);
 			expect(result).to.include(expectedCountryCode);
@@ -241,21 +275,21 @@ describe('ObjectUtils', () => {
 			expect(result).to.not.include('value');
 		});
 
-		it('should skip undefined items in arrays', () => {
-			const obj = { ids: [1, undefined, 3, undefined, 5] };
-			const result = ObjectUtils.serialize(obj);
-			// undefined items should be skipped
-			expect(result).to.equal('ids=1&ids=3&ids=5');
-			expect(result).to.not.include('undefined');
-		});
+	it('should skip undefined items in arrays', () => {
+		const obj = { ids: [1, undefined, 3, undefined, 5] };
+		const result = ObjectUtils.serialize(obj);
+		// undefined items should be skipped
+		expect(result).to.equal('ids[]=1&ids[]=3&ids[]=5');
+		expect(result).to.not.include('undefined');
+	});
 
-		it('should handle arrays with null items but skip undefined items', () => {
-			const obj = { values: [1, null, undefined, 'test'] };
-			const result = ObjectUtils.serialize(obj);
-			// null is kept as 'null', but undefined is skipped
-			expect(result).to.equal('values=1&values=null&values=test');
-			expect(result).to.not.include('undefined');
-		});
+	it('should handle arrays with null items but skip undefined items', () => {
+		const obj = { values: [1, null, undefined, 'test'] };
+		const result = ObjectUtils.serialize(obj);
+		// null is kept as 'null', but undefined is skipped
+		expect(result).to.equal('values[]=1&values[]=null&values[]=test');
+		expect(result).to.not.include('undefined');
+	});
 
 		it('should handle arrays with only undefined items', () => {
 			const obj = { name: 'test', ids: [undefined, undefined], other: 'data' };


### PR DESCRIPTION
…ay values and enhance test cases for better coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated query parameter serialization for arrays to use bracket notation (e.g., `ids[]=1&ids[]=2` for primitive values, `items[]=...` for objects), improving compatibility with standard parameter parsing conventions.

* **Tests**
  * Expanded test coverage to validate the updated array serialization format and edge case handling for arrays containing objects with undefined properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->